### PR TITLE
Fixed error in Wishart simulation

### DIFF
--- a/src/rags2ridges.cpp
+++ b/src/rags2ridges.cpp
@@ -774,7 +774,7 @@ arma::cube armaRWishart(const int n,
   --------------------------------------------------------------------------- */
 
   const int p = sigma.n_cols;
-  const arma::mat L = arma::chol(sigma);
+  const arma::mat L = arma::chol(sigma, "lower");
   arma::cube ans(p, p, n);
   for (int g = 0; g < n; ++g) {
     ans.slice(g) = armaRWishartSingle(L, nu, p);
@@ -797,7 +797,7 @@ arma::cube armaRInvWishart(const int n,
   --------------------------------------------------------------------------- */
 
   const int p = psi.n_cols ;
-  const arma::mat L = arma::chol(inv(psi));
+  const arma::mat L = arma::chol(inv(psi), "lower");
   arma::cube ans(p, p, n);
   for (int g = 0; g < n; ++g) {
     ans.slice(g) = inv(armaRWishartSingle(L, nu, p));


### PR DESCRIPTION
Issue discovered by @rfbrondum in AEBilgrau/correlateR@f86cea68b3285b3c64cd209e29bc94199baa1435:

 "The Barttlett decomposition for sampling from a wishart distribution used here requires the lower triangular matrix from the cholesky decomposition of psi, but the default behavior of arma::chol is according to the documentation to return the upper triangular matrix."