### PR TITLE
Fix for testthat 3.3.0

### DIFF
--- a/tests/testthat/test-armaRidgeP.R
+++ b/tests/testthat/test-armaRidgeP.R
@@ -63,7 +63,7 @@ for (type in tgt.types) {
     res <- armaRidgeP(S, tgt, l)
 
     test_that(paste("proper format for lambda =", l), {
-      expect_that(is.double(res), is_true())  # Returns numeric (dobule)
+      expect_true(is.double(res))  # Returns numeric (dobule)
       expect_that(res, is_a("matrix"))        # Returns a matrix
       expect_that(dim(res), equals(dim(S)))   # .. of the correct size
     })
@@ -94,10 +94,10 @@ for (type in tgt.types) {
       dd <- armaRidgeP(S, tgt, 1e-200)
       ee <- armaRidgeP(S, tgt, 1e-300)
 
-      expect_that(all(abs(aa) <= abs(bb)), is_true())
-      expect_that(all(abs(bb) <= abs(cc)), is_true())
-      expect_that(all(abs(cc) <= abs(dd)), is_true())
-      expect_that(all(abs(dd) <= abs(ee)), is_true())
+      expect_true(all(abs(aa) <= abs(bb)))
+      expect_true(all(abs(bb) <= abs(cc)))
+      expect_true(all(abs(cc) <= abs(dd)))
+      expect_true(all(abs(dd) <= abs(ee)))
     }
 
   })
@@ -117,7 +117,7 @@ source("reference-values.R")
 
 test_that("Test armaRidgeP in various special cases (by reference)", {
 
-  expect_that(any(!is.finite(armaRidgeP(Sbar, Tbar, aa))), is_false())
+  expect_false(any(!is.finite(armaRidgeP(Sbar, Tbar, aa))))
   expect_that(armaRidgeP(Sbar, Tbar, aa), equals(Tbar))
 
 })

--- a/tests/testthat/test-isSymmetricPD.R
+++ b/tests/testthat/test-isSymmetricPD.R
@@ -26,8 +26,8 @@ test_that("isSymmetricPD works as intended", {
   pdS    <- createS(n = 15, p = 10)
   notpdS <- createS(n = 5, p = 10)
 
-  expect_that(isSymmetricPD(pdS),    is_true())
-  expect_that(isSymmetricPD(notpdS), is_false())
+  expect_true(isSymmetricPD(pdS))
+  expect_false(isSymmetricPD(notpdS))
 
 })
 

--- a/tests/testthat/test-xfcvl.R
+++ b/tests/testthat/test-xfcvl.R
@@ -23,7 +23,7 @@ for (i in 1:4) {
 }
 
 test_that(".xfcl functions works properly on degenerated data", {
-  expect_that(TRUE, is_true())  # To be tested
+  expect_true(TRUE)  # To be tested
 })
 
 # Expand tests


### PR DESCRIPTION
`is_true()`, `is_false()`, and `is_null()` have been removed (after several years of deprecation) because they conflict with functions defined elsewhere in the tidyverse. I've updated your code to use the modern equivalent(s).

Unfortunately I couldn't get your package to compile so I couldn't verify that these are 100% correct, but hopefully they get you started.